### PR TITLE
Add some QoL

### DIFF
--- a/.code-workspace
+++ b/.code-workspace
@@ -1,0 +1,17 @@
+{
+	"folders": [
+		{
+			"name": "autocomplete-mentions",
+			"path": "."
+		},
+		{
+			"name": "modules",
+			"path": "/workspaces/data/Data/modules"
+		},
+		{
+			"name": "foundry",
+			"path": "/workspaces/app"
+		}
+	],
+	"settings": {}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/powershell:1": {
+			"version": "latest"
+		}
+	},
+	"mounts": [
+		{
+			"source": "${localEnv:FOUNDRYVTT_APP}",
+			"target": "/workspaces/app",
+			"type": "bind"
+		},
+		{
+			"source": "${localEnv:FOUNDRYVTT_DATA}",
+			"target": "/workspaces/data",
+			"type": "bind"
+		},
+		{
+			"source": "${localEnv:FOUNDRYVTT_DATA}/Data/modules/autocomplete-mentions",
+			"target": "/workspaces/fvtt-autocomplete-mentions/dist",
+			"type": "bind"
+		}
+	]
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 dist/
 coverage/
 .npmrc
+.vscode/launch.json

--- a/.vscode/launch.json.template
+++ b/.vscode/launch.json.template
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "msedge",
+            "request": "launch",
+            "name": "Launch Edge against localhost",
+            "url": "http://localhost:30000/",
+            "pathMapping": {
+                "/modules/autocomplete-mentions": "${workspaceFolder:autocomplete-mentions}/dist",
+                "/modules/": "${workspaceFolder:modules}",
+                "/": "${workspaceFolder:foundry}/public"
+            }
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "files.insertFinalNewline": false,
+    "editor.formatOnSave": false
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "debug",
+			"problemMatcher": [],
+			"label": "npm: debug",
+			"detail": "vite build --minify=false",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		}
+	]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## v1.1.0 - Lots of new features!
+![](https://img.shields.io/badge/release%20date-December%2031%2C%202023-blue)
+![GitHub release](https://img.shields.io/github/downloads-pre/dovrosenberg/fvtt-autocomplete-mentions/v1.1.0/module.zip)
+
+Many usability improvements, thanks to Sylvercode
+- Use selected text as initial search input
+  - Selected text will also be preserved as a manual label
+- Use the current filter as the default text when creating a new item
+- Easy ability to reference the current journal (when editing from inside a journal)
+- Ability to search compendia (and a setting to indicate which ones)
+- Ability to create a page in a journal
+- When creating a new document of the same type as the one being edited, put it in the same folder
+
+Also a bug fix (ditto on the credit):
+- Give focus back to the editor when closing the search box
+
 ## v1.0.1 - URL fix in module.json
 ![](https://img.shields.io/badge/release%20date-December%202%2C%202023-blue)
 ![GitHub release](https://img.shields.io/github/downloads-pre/dovrosenberg/fvtt-autocomplete-mentions/v1.0.1/module.zip)

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -20,6 +20,9 @@ Would love to have help providing translations to other languages
 
 ## Other thanks
 
+### Significant new features
+Sylvercode provided a huge set of quality of life functionality additions (and a bug fix) - see v1.1.0 for the full list - it's everything there.
+
 ### Inspiration
 The original structure (and UI) of this module was inspired by/copied from the [Autocomplete Inline Properties module](https://github.com/ghost-fvtt/FVTT-Autocomplete-Inline-Properties) by ghost.  [Tip](https://ko-fi.com/ghostfvtt) them - they do great work on all sorts of Foundry modules.
 

--- a/README.md
+++ b/README.md
@@ -60,13 +60,19 @@ I'm happy to do this for free, as I primarily work on things I like to use mysel
 Autocomplete Mentions is the result of the effort of many people (whether they know it or not). Please refer to [CREDITS.md](https://github.com/dovrosenberg/fvtt-autocomplete-mentions/blob/master/CREDITS.md) for the full list.
 
 ## How to Contribute
-
-When using [VSCode](https://code.visualstudio.com/), you can start a [dev container](https://code.visualstudio.com/docs/devcontainers/create-dev-container) for this repository. Before building it, be sure to have those environement variables sets:
-
+You can build the project either with local node or using a dev container.  In either case, make sure these environment variables are set:
 ```
 FOUNDRYVTT_APP=<absolute path to your foundry installation>
 FOUNDRYVTT_DATA=<absolute path to your foundry data directory>
 ```
+
+### Natively
+`npm install` to get started.
+
+`npm run linkdata` will create a symlink between the output directory and your foundry modules data.  Then `npm run debug` will compile the project and update Foundry.  You'll still need to activate the module in your game to test it.
+
+### Using a dev container
+When using [VSCode](https://code.visualstudio.com/), you can start a [dev container](https://code.visualstudio.com/docs/devcontainers/create-dev-container) for this repository. 
 
 Once in VSCode-RemoteContainer, use `File: Open workspace from file...` to open the `.code-workspace` file. It will give you acces to the current module, all installed modules and the foundry app to debug.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ I'm happy to do this for free, as I primarily work on things I like to use mysel
 
 Autocomplete Mentions is the result of the effort of many people (whether they know it or not). Please refer to [CREDITS.md](https://github.com/dovrosenberg/fvtt-autocomplete-mentions/blob/master/CREDITS.md) for the full list.
 
+## How to Contribut
+
+When using [VSCode](https://code.visualstudio.com/), you can start a [dev container](https://code.visualstudio.com/docs/devcontainers/create-dev-container) for this repository. Before building it, be sure to have those environement variables sets:
+
+```
+FOUNDRYVTT_APP=<absolute path to your foundry insllation>
+FOUNDRYVTT_DATA=<absolute path to your foundry data directory>
+```
+
+Once in VSCode-RemoteContainer, use `File: Open workspace from file...` to open the `.code-workspace` file. It will give you acces to the current module, all installed modules and the foundry app to debug.
+
+Use `npm install` and ` npm debug` to create the module in your foundry installation. The module should not already be present in foundry.
+
+While your foundry app is running, use the web debugger (like [edge tool](https://marketplace.visualstudio.com/items?itemName=ms-edgedevtools.vscode-edge-devtools)) using the exemple in `.vscode/launch.json.template` as `.vscode/launch.json` to debug the module.
 
 ## Copyright and usage
 THIS ENTIRE REPOSITORY IS COVERED BY THIS LICENSE AND COPYRIGHT NOTICE

--- a/README.md
+++ b/README.md
@@ -7,22 +7,41 @@ Quickly insert cross-references to actors, items, scenes, roll tables, and journ
 ## Features
 - Facilitate your world building by rapidly cross-referencing other parts of your world as you write, 
 without needing to stop to drag & drop or even create a new element. 
-- Insert references to actors, items, journals (and pages), scenes, and roll tables.
+- Insert references to actors, items, journals (and pages), scenes, and roll tables (including in Compendia).
 - Quickly create new documents (actors, etc.) with a couple of keystrokes, simultaneously inserting a reference 
 to the newly created element into the editor.
 - Inserts references as pure UUID so that the link text updates when the name of the referenced item changes 
 
+
 ## How it works
+### The basics
 - Typing @ in any* Foundry VTT editor will pop open a context menu where you can select the type of document.
 - Select the document type by using the up/down arrows and enter key, typing the first letter as indicated, 
 or clicking with the mouse
 - You'll then get a list of the available documents of that type.  Start typing to filter the list.  Filtering is Foundry's full-text search (which currently appears to only search the name field, but finds matches in any part of the field - not just the start.  For example, 'j', 'jo', and 'oe' would all be matches for an actor named 'Joe'). Searching is not case sensitive.
-- You can select the document you want with the arrow/enter keys or clicking with the mouse.  You can also use the "Create" button to quickly create a new document while simultaneously inserting a reference to it.
-- In the case of journal entries, once you pick the main entry, you'll get a subscreen where you can search for and select a specific page to refer to (or just pick the option to point to the overall entry).
+  - If you highlight text in the editor before pressing @, that text will become the initial filter
+- You can select the document you want with the arrow/enter keys or clicking with the mouse.  
 - Backspace will delete characters from the search string, and when the search string is empty, it will also go back to the prior menu.  
 - The Escape key will close the menu without inserting a reference.  Pressing escape immediately on the first menu after typing '@' will insert a '@' character in the editor for scenarios where you need that character. 
-- There is a module setting to set the maximum number of search results that will show at one time.  If you set it really high, I take no responsibility for failures of the UI to accomodate. :) 
+
+### Creating new documents
+- You can use the "Create" option to quickly create a new document while simultaneously inserting a reference to it.
+- The current filter will become the default name of the new document.  Unfortunately, it can't currently be edited.  To use it as is, simply leave the name field in the dialog alone.  To make a change, just put in your desired value.
+- When creating a new document of the same type as the one being edited (for example, you're linking to another Actor related to the one you are editing), the new document will be put in the same compendium and folder as the one being edited.
+
+### Inserted text
 - Note that links will be inserted as just UUID references, which means that when you view the text (not in edit mode), you'll see the current name of the referenced document - even if it has changed since the link was inserted. If you want to have the link text set permanently, regardless of future changes to the document name, you can manually add the text. For example, you might get a reference like: `@UUID[Actor.E6azrOSJJfSxvgty]`. By adding text in curly brackets immediately afterward (ex. `@UUID[Actor.E6azrOSJJfSxvgty]{Joe}`), you can make the link text read "Joe", even if you change the Actor's name in the future, while ensuring the link continues to work.
+- Any highlighted text in the editor when you press @ will become the label on the link - even if you subsequently change the filter.  For example, if you highlight 'her cousin' and press @, then press A to select 'Actors', you'll see a list filtered by the text 'her cousin'.  If you backspace to remove that text and then pick an actor named 'Joe', when you insert it you will get a link like `@UUID[Actor.E6azrOSJJfSxvgty]{her cousin}` that (when you close the editor) says 'her cousin' but links to Joe.
+
+### Journal entries
+- In the case of journal entries, once you pick the main entry, you'll get a subscreen where you can search for and select a specific page to create/refer to, or you can pick the option to point to the overall journal entry.
+
+### Number of results
+- There is a module setting to set the maximum number of search results that will show at one time.  If you set it really high, I take no responsibility for failures of the UI to accomodate. :) 
+
+### Compendia
+- There is a module setting to specify a list of compendia to be searched.  
+- If the document being edited is in a compendium, then compendia will be searched first for any results.  If it is not, then compendia will be searched last (and thus any matching results will only be shown if there aren't sufficient results in the world data).
 
 \* Note: Supports the new (standard) ProseMirror editor, as well as TinyMCE - send me a feature request if 
 you need a different one

--- a/README.md
+++ b/README.md
@@ -40,18 +40,20 @@ I'm happy to do this for free, as I primarily work on things I like to use mysel
 
 Autocomplete Mentions is the result of the effort of many people (whether they know it or not). Please refer to [CREDITS.md](https://github.com/dovrosenberg/fvtt-autocomplete-mentions/blob/master/CREDITS.md) for the full list.
 
-## How to Contribut
+## How to Contribute
 
 When using [VSCode](https://code.visualstudio.com/), you can start a [dev container](https://code.visualstudio.com/docs/devcontainers/create-dev-container) for this repository. Before building it, be sure to have those environement variables sets:
 
 ```
-FOUNDRYVTT_APP=<absolute path to your foundry insllation>
+FOUNDRYVTT_APP=<absolute path to your foundry installation>
 FOUNDRYVTT_DATA=<absolute path to your foundry data directory>
 ```
 
 Once in VSCode-RemoteContainer, use `File: Open workspace from file...` to open the `.code-workspace` file. It will give you acces to the current module, all installed modules and the foundry app to debug.
 
-Use `npm install` and ` npm debug` to create the module in your foundry installation. The module should not already be present in foundry.
+(Or, from VS Code palette, run `Dev Containers:Open folder in container...` to start and go right to the container from any VS Code window)
+
+Use `npm install` and `npm run debug` to create the module in your foundry installation. The module should not already be present in foundry.
 
 While your foundry app is running, use the web debugger (like [edge tool](https://marketplace.visualstudio.com/items?itemName=ms-edgedevtools.vscode-edge-devtools)) using the exemple in `.vscode/launch.json.template` as `.vscode/launch.json` to debug the module.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fvtt-autocomplete-mentions",
-  "version": "0.0.5",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fvtt-autocomplete-mentions",
-      "version": "0.0.5",
+      "version": "1.0.1",
       "devDependencies": {
         "@league-of-foundry-developers/foundry-vtt-types": "9.280.0",
         "@originjs/vite-plugin-commonjs": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fvtt-autocomplete-mentions",
   "title": "Foundry VTT Autocomplete Mentions",
-  "version": "1.0.1", 
+  "version": "1.1.0", 
   "description": "Easily reference actors, scenes, items, etc. in the editor.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   "scripts": {
     "build": "vite build",
     "debug": "vite build --minify=false",
-    "copy": "rm -rf ~/foundryData/Data/modules/autocomplete-mentions/* && cp -r $(pwd)/dist/* ~/foundryData/Data/modules/autocomplete-mentions",
-    "linkdata": "ln -s $PWD/dist ~/foundryData/Data/modules/autocomplete-mentions",
+    "copy": "rm -rf $FOUNDRYVTT_DATA/Data/modules/autocomplete-mentions/* && cp -r $(pwd)/dist/* ~/foundryData/Data/modules/autocomplete-mentions",
+    "linkdata": "ln -s $PWD/dist $FOUNDRYVTT_DATA/Data/modules/autocomplete-mentions",
     "tsc": "tsc --noEmit --skipLibCheck",
-    "unlinkdata": "unlink ~/foundryData/Data/modules/autocomplete-mentions",
+    "unlinkdata": "unlink $FOUNDRYVTT_DATA/Data/modules/autocomplete-mentions",
     "buildcopy": "npm run build && npm run copy",
-    "foundry": "node ~/foundry/resources/app/main.js",
+    "foundry": "node $FOUNDRYVTT_APP/resources/app/main.js",
     "foundry10": "node ~/foundry10/resources/app/main.js --dataPath=/home/dov/foundry10data",
     "version": "node ./scripts/increment-version.js"
   },

--- a/src/autocomplete/autocompleter.ts
+++ b/src/autocomplete/autocompleter.ts
@@ -550,18 +550,20 @@ export class Autocompleter extends Application {
       return;
     }
 
+    // Check how many result make the <...> appear.
     const OVERFLOW_LENGTH = moduleSettings.get(SettingKeys.resultLength) + 1;
     let results = [] as DocumentType[];
 
     const curMainDoc = this._currentDoc.parent ?? this._currentDoc;
     const curCompedium = curMainDoc.compendium?.collection;
 
+    // If we are editing from a compendium, search compendiums first.
     if (curCompedium) {
         results = await this._searchCompediums(OVERFLOW_LENGTH, docType.referenceText);
     }
 
+    // Check in game document (not in compendium)
     const collection = getGame()[docType.collectionName] as DocumentType11;
-
     const FULL_TEXT_SEARCH = true;   // TODO: pull from settings; at the moment, only name seems to be searchable
     if (FULL_TEXT_SEARCH) {
       results = results.concat(collection.search({query: this._shownFilter, filters:[]}) as DocumentType[]);
@@ -569,6 +571,7 @@ export class Autocompleter extends Application {
       //results.concat(collection.search({query: this._shownFilter, filters: [nameFilter]}));
     }
 
+    // If we are not editing from a compendium, search compendiums last.
     if (!curCompedium) {
       const compediumResult = await this._searchCompediums(OVERFLOW_LENGTH - results.length, docType.referenceText);
       results = results.concat(compediumResult);
@@ -644,9 +647,11 @@ export class Autocompleter extends Application {
 
   private async _searchCompediums(maxResultCount: number, documentName: string) {
     let results = [] as DocumentType[];
+    // No need to do anything if there is no place for any result.
     if (maxResultCount < 1)
       return results;
 
+    // Check in the settings what are the compendium to include.
     const INCL_COMP = moduleSettings.get(SettingKeys.includedCompedium) as string;
     if (!INCL_COMP)
       return results;

--- a/src/autocomplete/autocompleter.ts
+++ b/src/autocomplete/autocompleter.ts
@@ -324,7 +324,9 @@ export class Autocompleter extends Application {
                     ? {
                       uuid: this._currentDoc.parent.uuid,
                       name: this._currentDoc.parent.name,
-                      pages: this._currentDoc.parent.pages }
+                      pages: this._currentDoc.parent.pages,
+                      journal: this._currentDoc.parent
+                      }
                     : this._filteredSearchResults[this._focusedMenuKey - 2];
                   this._selectedJournal = {...journal};
 

--- a/src/autocomplete/autocompleter.ts
+++ b/src/autocomplete/autocompleter.ts
@@ -325,7 +325,7 @@ export class Autocompleter extends Application {
                       uuid: this._currentDoc.parent.uuid,
                       name: this._currentDoc.parent.name,
                       pages: this._currentDoc.parent.pages }
-                    : this._filteredSearchResults[this._focusedMenuKey - 1];
+                    : this._filteredSearchResults[this._focusedMenuKey - 2];
                   this._selectedJournal = {...journal};
 
                   // reset search

--- a/src/autocomplete/autocompleter.ts
+++ b/src/autocomplete/autocompleter.ts
@@ -598,8 +598,9 @@ export class Autocompleter extends Application {
 
     const collection = getGame()[docTypeInfo.collectionName] as DocumentType;
 
+    // Use de current filter as default name
     // TODO: maybe default the folder to what's currently open?
-    const data = {folder: undefined };
+    const data = { folder: undefined, name: this._shownFilter };
     const options = {width: 320, left: 300, top: 300 };
 
     // register the hook to catch after the document is made
@@ -612,6 +613,16 @@ export class Autocompleter extends Application {
     const cls = getDocumentClass(collection.documentName);
     cls.createDialog(data, options).then((result) => {
       if (result) {
+        // Check if we had a default name and if the user did not change it.
+        // Foundry override the name if the user enter nothing.
+        //    Check if foundry use it's default name and change it to our.
+        if (this._shownFilter.length > 0) {
+          const label = game.i18n.localize(cls.metadata.label);
+          const docDefaultName = game.i18n.format("DOCUMENT.New", { type: label });
+          if (result.name.startsWith(docDefaultName)) {
+            result.update({ name: this._shownFilter });
+          }
+        }
         // it was created
         if (range) {
           selection?.removeAllRanges();

--- a/src/autocomplete/autocompleter.ts
+++ b/src/autocomplete/autocompleter.ts
@@ -51,6 +51,7 @@ export class Autocompleter extends Application {
   private _searchDocType = null as ValidDocType | null;   // if we're in doc search mode, the key of the docType to search
   private _selectedJournal: SearchResult;   // name of the selected journal when we're looking for pages
   private _shownFilter = '' as string;    // current filter for doc search
+  private _lastJournalSearch = '';
 
   // search results
   private _lastPulledSearchResults = [] as SearchResult[];  // all of the results we got back last time
@@ -328,6 +329,7 @@ export class Autocompleter extends Application {
                   this._selectedJournal = {...journal};
 
                   // reset search
+                  this._lastJournalSearch = this._shownFilter;
                   this._shownFilter = '';
                   this._focusedMenuKey = 0;   // use whole journal
                   this._journalSearchFromPageEdition = false;
@@ -370,7 +372,7 @@ export class Autocompleter extends Application {
                 } else {
                   // journal search
                   this._currentMode = AutocompleteMode.docSearch;
-                  this._shownFilter = '';
+                  this._shownFilter = this._lastJournalSearch;
                   this._journalSearchFromPageEdition = this._currentDoc.documentName === 'JournalEntryPage'
                   await this._refreshSearch();
                 }

--- a/src/autocomplete/autocompleter.ts
+++ b/src/autocomplete/autocompleter.ts
@@ -602,7 +602,7 @@ export class Autocompleter extends Application {
         return {
           uuid: item.uuid,
           name,
-          journal: item
+          parentJournal: item
         }
       return { uuid: item.uuid, name }
     }) as SearchResult[];

--- a/src/autocomplete/autocompleter.ts
+++ b/src/autocomplete/autocompleter.ts
@@ -353,12 +353,12 @@ export class Autocompleter extends Application {
                   this._createDocument(this._searchDocType);
                 }
                 // if it's 1, we just add a reference to the whole journal
-                else if (!this._focusedMenuKey === 1) {
+                else if (this._focusedMenuKey === 1) {
                   this._insertReferenceAndClose(this._selectedJournal.uuid);
                 } else {
                   // pages have to be entered as a UUID
                   // get the clicked item
-                  const item = this._filteredSearchResults[this._focusedMenuKey-1];
+                  const item = this._filteredSearchResults[this._focusedMenuKey-2];
 
                   // insert the appropriate text
                   if (item) {

--- a/src/autocomplete/autocompleter.ts
+++ b/src/autocomplete/autocompleter.ts
@@ -583,14 +583,29 @@ export class Autocompleter extends Application {
 
     // pages OK here despite typescript
     this._lastPulledSearchResults = results.map((item) => {
+      const pack = (() => {
+        // There is no compendium to display in name if the result is not from one.
+        if (!item.pack)
+          return '';
+
+        // When the result is in the same compendium explicitly show it.
+        const curMainDoc = this._currentDoc.parent ?? this._currentDoc;
+        if (curMainDoc.compendium?.collection === item.pack)
+          return ` (this compendium)`;
+        
+        return ` (${item.pack})`;
+      })();
+
+      const name = `${item.name}${pack}`;
+
       if (this._searchDocType === ValidDocType.Journal)
         return {
           uuid: item.uuid,
-          name: item.name,
+          name,
           pages: item.pages,
           journal: item
         }
-      return { uuid: item.uuid, name: item.name }
+      return { uuid: item.uuid, name }
     }) as SearchResult[];  
     return;
   }

--- a/src/autocomplete/autocompleter.ts
+++ b/src/autocomplete/autocompleter.ts
@@ -628,7 +628,9 @@ export class Autocompleter extends Application {
   }
 
   private _insertReferenceAndClose(uuid: string): void {
-    this._insertTextAndClose(`@UUID[${uuid}]`);
+    const selectedTextInEditor = this._editor.ownerDocument.getSelection()?.toString();
+    const label = selectedTextInEditor ? `{${selectedTextInEditor}}` : '';
+    this._insertTextAndClose(`@UUID[${uuid}]${label}`);
   }
 
   private _insertTextAndClose(text: string): void {

--- a/src/autocomplete/autocompleter.ts
+++ b/src/autocomplete/autocompleter.ts
@@ -285,6 +285,11 @@ export class Autocompleter extends Application {
       case AutocompleteMode.journalPageSearch: {
         // if it's a regular character, update the filter string
         if (event.key.length===1) {
+          // if the filter is the same as the default, we want to start a new search.
+          if (this._shownFilter === this._editor.ownerDocument.getSelection()?.toString()) {
+            this._shownFilter = '';
+          }
+
           this._shownFilter += event.key;
 
           await this._refreshSearch();
@@ -571,7 +576,7 @@ export class Autocompleter extends Application {
   private async _moveToDocSearch(docType: ValidDocType) {
     this._currentMode = AutocompleteMode.docSearch
     this._searchDocType = docType;
-    this._shownFilter = '';
+    this._shownFilter = this._editor.ownerDocument.getSelection()?.toString() || '';
     this._focusedMenuKey = 0;
     await this._refreshSearch();
   }

--- a/src/autocomplete/autocompleter.ts
+++ b/src/autocomplete/autocompleter.ts
@@ -246,6 +246,7 @@ export class Autocompleter extends Application {
 
           case 'Backspace': {
             // close the menu
+            this._editor.focus()
             this.close();
             return;
           }
@@ -363,6 +364,7 @@ export class Autocompleter extends Application {
             
             case "Escape": {
               // just close the whole menu (without inserting @, because it's more likely we just changed our mind)
+              this._editor.focus()
               this.close();
               return;
             }

--- a/src/autocomplete/autocompleter.ts
+++ b/src/autocomplete/autocompleter.ts
@@ -332,7 +332,17 @@ export class Autocompleter extends Application {
 
                   // reset search
                   this._lastJournalSearch = this._shownFilter;
-                  this._shownFilter = '';
+                  this._shownFilter = (() => {
+                    const selectedTextInEditor = this._editor.ownerDocument.getSelection()?.toString();
+                    // If there is a selected texte in the editor and
+                    // it was not use as filter to select the journal:
+                    // but back the selectge text as filter for the page.
+                    if (selectedTextInEditor &&
+                        (this._focusedMenuKey === 1 || this._shownFilter !== selectedTextInEditor))
+                      return selectedTextInEditor ;
+                      
+                    return '';
+                  })();
                   this._focusedMenuKey = 0;   // use whole journal
                   this._journalSearchFromPageEdition = false;
                   await this._refreshSearch();

--- a/src/autocomplete/autocompleter.ts
+++ b/src/autocomplete/autocompleter.ts
@@ -42,6 +42,7 @@ export class Autocompleter extends Application {
   private _location: WindowPosition;   // location of the popup
   private _editor: HTMLElement;    // the editor element
   private _editorType: EditorType;   // the type of editor we're supporting
+  private _currentDoc: any;    // current document being edited
 
   // status
   private _currentMode: AutocompleteMode;
@@ -59,6 +60,8 @@ export class Autocompleter extends Application {
 
   constructor(target: HTMLElement, editorType: EditorType, onClose: ()=>void) {
     super();
+
+    this._currentDoc = ui.activeWindow.document;
 
     log(false, 'Autocompleter construction');
 
@@ -599,8 +602,7 @@ export class Autocompleter extends Application {
     const collection = getGame()[docTypeInfo.collectionName] as DocumentType;
 
     // Use de current filter as default name
-    // TODO: maybe default the folder to what's currently open?
-    const data = { folder: undefined, name: this._shownFilter };
+    const data = { folder: this._currentDoc.parent.folder.id, name: this._shownFilter };
     const options = {width: 320, left: 300, top: 300 };
 
     // register the hook to catch after the document is made

--- a/src/autocomplete/autocompleter.ts
+++ b/src/autocomplete/autocompleter.ts
@@ -619,9 +619,14 @@ export class Autocompleter extends Application {
 
     const collection = getGame()[docTypeInfo.collectionName] as DocumentType;
 
+    // If we are creating a new entry of the same type of the document we are editing,
+    // create it in the same pack/compedium and folder.
+    const curMainDoc = this._currentDoc.parent ?? this._currentDoc;
+    const curPack = (curMainDoc.documentName === collection.documentName) ? curMainDoc.compendium?.collection: null;
+    const curFolder = (curMainDoc.documentName === collection.documentName) ? curMainDoc.folder?.id : null;
     // Use de current filter as default name
-    const data = { folder: this._currentDoc.parent.folder.id, name: this._shownFilter };
-    const options = {width: 320, left: 300, top: 300 };
+    const data = { folder: curFolder, name: this._shownFilter };
+    const options = { width: 320, left: 300, top: 300, pack: curPack };
 
     // register the hook to catch after the document is made
     // we need to save the current editor selection because it goes away when the new boxes pop up

--- a/src/settings/ModuleSettings.ts
+++ b/src/settings/ModuleSettings.ts
@@ -4,7 +4,7 @@ import moduleJson from '@module';
 export enum SettingKeys {
   // displayed in settings
   resultLength = 'resultLength',
-
+  includedCompedium = 'includedCompedium'
   // internal only
 }
 
@@ -59,6 +59,13 @@ export class ModuleSettings {
       default: 5,
       type: Number,
     },
+    {
+      settingID: SettingKeys.includedCompedium,
+      name: 'acm.settings.includedCompedium',
+      hint: 'acm.settings.includedCompediumHelp',
+      default: '',
+      type: String,
+    }
   ];
 
   // these are client-specific and displayed in settings

--- a/src/settings/ModuleSettings.ts
+++ b/src/settings/ModuleSettings.ts
@@ -4,12 +4,13 @@ import moduleJson from '@module';
 export enum SettingKeys {
   // displayed in settings
   resultLength = 'resultLength',
-  includedCompedium = 'includedCompedium'
+  includedCompendia = 'includedCompendia'
   // internal only
 }
 
 type SettingType<K extends SettingKeys> =
     K extends SettingKeys.resultLength ? number :
+    K extends SettingKeys.includedCompendia ? string :
     never;  
 
 // the solo instance
@@ -60,9 +61,9 @@ export class ModuleSettings {
       type: Number,
     },
     {
-      settingID: SettingKeys.includedCompedium,
-      name: 'acm.settings.includedCompedium',
-      hint: 'acm.settings.includedCompediumHelp',
+      settingID: SettingKeys.includedCompendia,
+      name: 'acm.settings.includedCompendia',
+      hint: 'acm.settings.includedCompendiaHelp',
       default: '',
       type: String,
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,8 +24,6 @@ export enum ValidDocType {
   Scene,
 }
 
-export type DocumentType = Actor | Scene | JournalEntry | RollTable | Item;
-
 export enum EditorType {
   ProseMirror,
   TinyMCE
@@ -38,7 +36,7 @@ export type ui11 = typeof ui & {
   activeWindow: DocumentSheet
 }
 
-export type DocumentType11 = DocumentType & {
+export type DocumentType11 = (Actor | Scene | JournalEntry | RollTable | Item) & {
   search(options: { query: string, filters?: string[], exclude?: string[] })
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,3 @@
-import EmbeddedCollection from '@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/abstract/embedded-collection.mjs';
-
 export enum AutocompleteMode {
   singleAtWaiting,  // entered a single @ and waiting for next char to determine what type of search (this is the default when we open it)
   docSearch, // entered a single @ plus a valid document search type
@@ -15,8 +13,7 @@ export type WindowPosition = {
 export type SearchResult = {
   uuid: string;
   name: string;
-  pages: EmbeddedCollection<any, any> | null;
-  journal: JournalEntry | null
+  parentJournal: JournalEntry11 | null
 }
 
 export enum ValidDocType {
@@ -32,4 +29,22 @@ export type DocumentType = Actor | Scene | JournalEntry | RollTable | Item;
 export enum EditorType {
   ProseMirror,
   TinyMCE
+}
+
+// Below are some foundry type amendments.Since Foundry Types are supported up to 10,
+// any definition added by version 11 are below.Those are not real definitions.
+// They are only close enough to make the compilation with fewer false errors.
+export type ui11 = typeof ui & {
+  activeWindow: DocumentSheet
+}
+
+export type DocumentType11 = DocumentType & {
+  search(options: { query: string, filters?: string[], exclude?: string[] })
+}
+
+export type JournalEntry11 = typeof JournalEntry & {
+  pages: JournalEntry11
+  contents: { at(idx: number): JournalEntry11 }
+  sort: number
+  search(options: { query: string, filters?: string[], exclude?: string[] })
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,7 +13,7 @@ export type WindowPosition = {
 export type SearchResult = {
   uuid: string;
   name: string;
-  parentJournal: JournalEntry11 | null
+  parentJournal?: JournalEntry11
 }
 
 export enum ValidDocType {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,7 @@ export type SearchResult = {
   uuid: string;
   name: string;
   pages: EmbeddedCollection<any, any> | null;
+  journal: JournalEntry | null
 }
 
 export enum ValidDocType {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -3,8 +3,8 @@
     "settings": {
       "resultLength": "Result length",
       "resultLengthHelp": "Number of results to show at a time when searching",
-      "includedCompedium": "Included compedium to search",
-      "includedCompediumHelp": "List of compendiums separated by column to include in search. (RegEx accepted)"
+      "includedCompendia": "Compendia to include when searching",
+      "includedCompendiaHelp": "List of compendia separated by comma (RegEx accepted)"
     },
     "documents": {
       "titles": {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -2,7 +2,9 @@
   "acm": {
     "settings": {
       "resultLength": "Result length",
-      "resultLengthHelp": "Number of results to show at a time when searching"
+      "resultLengthHelp": "Number of results to show at a time when searching",
+      "includedCompedium": "Included compedium to search",
+      "includedCompediumHelp": "List of compendiums separated by column to include in search. (RegEx accepted)"
     },
     "documents": {
       "titles": {

--- a/static/templates/autocompleter.hbs
+++ b/static/templates/autocompleter.hbs
@@ -23,9 +23,11 @@
             <li class="acm-static-entry flexrow">
               Searching pages for '{{shownFilter}}'
             </li>
-            <li><hr></li> <li class="acm-data-entry flexrow{{#if (eq 0 highlightedEntry)}} highlighted{{/if}}" data-acm-index="0">
-              Create new...
-            </li><li class="acm-data-entry flexrow{{#if (eq 1 highlightedEntry)}} highlighted{{/if}}" data-acm-index="0">
+            <li><hr></li> 
+            <li class="acm-data-entry flexrow{{#if (eq 0 highlightedEntry)}} highlighted{{/if}}" data-acm-index="0">
+              Create new page...
+            </li>
+            <li class="acm-data-entry flexrow{{#if (eq 1 highlightedEntry)}} highlighted{{/if}}" data-acm-index="0">
               Link whole journal entry
             </li>
           {{else}}
@@ -36,10 +38,10 @@
             <li class="acm-data-entry flexrow{{#if (eq 0 highlightedEntry)}} highlighted{{/if}}" data-acm-index="0">
               Create new...
             </li>
-            {{#if journalSearchFromPageEdition}}
-            <li class="acm-data-entry flexrow{{#if (eq 1 highlightedEntry)}} highlighted{{/if}}" data-acm-index="1">
-              Search page in current journal...
-            </li>
+            {{#if searchingFromJournalPage}}
+              <li class="acm-data-entry flexrow{{#if (eq 1 highlightedEntry)}} highlighted{{/if}}" data-acm-index="1">
+                Current journal...
+              </li>
             {{/if}}
           {{/if}}
 

--- a/static/templates/autocompleter.hbs
+++ b/static/templates/autocompleter.hbs
@@ -35,10 +35,15 @@
             <li class="acm-data-entry flexrow{{#if (eq 0 highlightedEntry)}} highlighted{{/if}}" data-acm-index="0">
               Create new...
             </li>
+            {{#if journalSearchFromPageEdition}}
+            <li class="acm-data-entry flexrow{{#if (eq 1 highlightedEntry)}} highlighted{{/if}}" data-acm-index="1">
+              Search page in current journal...
+            </li>
+            {{/if}}
           {{/if}}
 
           {{#each searchResults}}
-            <li id="menu-item-{{acm-add @index 1}}" class="acm-data-entry flexrow{{#if (eq (acm-add @index 1) ../highlightedEntry)}} highlighted{{/if}}" data-acm-index="{{acm-add @index 1}}">
+            <li id="menu-item-{{acm-add @index ../firstSearchIdx}}" class="acm-data-entry flexrow{{#if (eq (acm-add @index ../firstSearchIdx) ../highlightedEntry)}} highlighted{{/if}}" data-acm-index="{{acm-add @index ../firstSearchIdx}}">
               <span class="acm-key">{{{name}}}</span>
             </li>
           {{/each}}

--- a/static/templates/autocompleter.hbs
+++ b/static/templates/autocompleter.hbs
@@ -23,8 +23,9 @@
             <li class="acm-static-entry flexrow">
               Searching pages for '{{shownFilter}}'
             </li>
-            <li><hr></li> 
-            <li class="acm-data-entry flexrow{{#if (eq 0 highlightedEntry)}} highlighted{{/if}}" data-acm-index="0">
+            <li><hr></li> <li class="acm-data-entry flexrow{{#if (eq 0 highlightedEntry)}} highlighted{{/if}}" data-acm-index="0">
+              Create new...
+            </li><li class="acm-data-entry flexrow{{#if (eq 1 highlightedEntry)}} highlighted{{/if}}" data-acm-index="0">
               Link whole journal entry
             </li>
           {{else}}


### PR DESCRIPTION
I want to get rid of my current Campain Manager service that cost too much for what it is. [fvtt-autocomplete-mentions](https://github.com/dovrosenberg/fvtt-autocomplete-mentions) add the most needed feature to FoundryVTT but it miss some QoL to make it a real deal breaker to the costly Campain Manager.

 - (*dev only*) add some config file to develop in a dev container using VSCode.
 - (*bug correction*) Give the focus back to the editor when we close search box.
 - Use the selected text as first input for the search filter. 
   - If the selected text was not use as filter to select a journal, use the selected text again to filter pages.
   - When a texte selection start the search, the creating link keep the selected text.
 - Creating a new document use the currently typed filter as the name in the creation windows
   - Foundry do not really support it, but I use the [placeholder](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#placeholder) and detect if nothing was typed.
 - When editing a journal and selecting to link a journal, add a new choice to select the current journal and search its pages.
 - Add the ability to search compendium by adding a setting to indicates which one.
   - When editing from a compendium, the compendium results appears first.
   - When editing from a compendium, new document of the same type of the edited one are created in the compendium.
 - Page in journal can be created.
 - Use the same folder as the currently edited document if the new document is the same type.

If you take my changes, I will push you another one to add those changes to the change log and follow you TODOs to make a new release.